### PR TITLE
Update `update_index.sh` to ignore Emacs backup files

### DIFF
--- a/update_index.sh
+++ b/update_index.sh
@@ -1,6 +1,4 @@
 # updating index file name
 
 printf "This file must have the tree file system.\nIf you're in linux, write tree, copy and paste here\n\n" > INDEX
-tree >> INDEX
-
-
+tree -I "*~" >> INDEX


### PR DESCRIPTION
Avoids to add Emacs backup files to `INDEX` file.