### PR TITLE
Adds on-folder-elisp package and configuration for update INDEX

### DIFF
--- a/.on-folder-elisp-script.el
+++ b/.on-folder-elisp-script.el
@@ -1,0 +1,8 @@
+;; Elisp on folder.
+
+;; Add the package `on-folder-elisp' and set your `after-save-hook' to
+;; execute this file on any on-save event of any file on this folder
+;; and subfolders.
+
+(message "Executing Elisp on folder.")
+(shell-command "sh update_index.sh")

--- a/Examples/.on-folder-elisp-script.el
+++ b/Examples/.on-folder-elisp-script.el
@@ -1,0 +1,2 @@
+(message "Elisp on directory executed.")
+(setq found t)

--- a/Examples/on-folder-elisp.el
+++ b/Examples/on-folder-elisp.el
@@ -1,0 +1,44 @@
+;;; on-folder-elisp.el --- Eval a Elisp file on current or parenting folder
+
+;; Version: 0
+;; Homepage: https://github.com/89453728/Learning-Lisp.git
+
+
+;;; Commentary:
+;; On folder elisp.
+;;
+;; Look for a Elisp file named after `on-folder-elisp-file' variable
+;; on current or parent folder and eval the file if it is found.  The
+;; inspiration comes from
+;; http://www.howardism.org/Technical/Emacs/save-hooks.html by Howard
+;; where executes a script on a current directory or a parenting one.
+;; So I have just adapted a bit to evaluate a Elisp file.
+;;
+;; Installation.
+;;
+;; (add-to-list load-path "path/to/package")
+;; (add-hook 'after-save-hook 'on-folder-elisp-hook)
+;;
+;; Create a .el file named after `on-folder-elisp-file' custom
+;; variable and add to it what you want to eval on hook evaluation.
+
+;;; Code:
+
+(defcustom on-folder-elisp-file ".on-folder-elisp-script.el"
+  "A Elisp file that is seek to be evaluated.")
+
+(defun on-folder-elisp-hook ()
+  "Hook that look for a Elisp file on current or parent folders and
+evaluates it."
+  (if (and
+       (boundp 'on-folder-elisp-file)
+       on-folder-elisp-file
+       (not (equal "" on-folder-elisp-file)))
+      (let ((script-folder (locate-dominating-file
+                            (buffer-file-name) on-folder-elisp-file)))
+        (when (file-exists-p (concat script-folder on-folder-elisp-file))
+          (load-file (concat script-folder on-folder-elisp-file))))))
+
+(provide 'on-folder-elisp)
+
+;;; on-folder-elisp.el ends here

--- a/Examples/on-folder-elisp.test.el
+++ b/Examples/on-folder-elisp.test.el
@@ -1,0 +1,91 @@
+;;; Test suit for `on-folder-elisp.el'.
+
+;; To run tests cases:
+;;
+;; 1. Eval both `on-folder-elisp.test.el' and `on-folder-elisp.el'
+;; files.
+;;
+;; 2. M-x ert t
+
+(require 'on-folder-elisp)
+
+(ert-deftest test-on-folder-elisp-hook()
+  "Expects to find and eval a Elisp file on a parent
+directory."
+  (let ((found nil)
+        (rootdirectory "/tmp/")
+        (subdirectory "/tmp/subdirectory/")
+        (file "testing-on-save.el"))
+    (unwind-protect
+        (progn
+          (dired-create-directory subdirectory)
+          (copy-file on-folder-elisp-file (concat rootdirectory on-folder-elisp-file))
+          (add-hook 'after-save 'on-folder-elisp-hook)
+          (with-current-buffer
+              (find-file-noselect (concat subdirectory file))
+            (run-hooks 'after-save)))
+      (remove-hook 'after-save 'on-folder-elisp-hook)
+      (delete-file (concat subdirectory file))
+      (delete-directory subdirectory)
+      (delete-file (concat rootdirectory on-folder-elisp-file)))
+    (should (eq found t))))
+
+(ert-deftest test-on-folder-elisp-hook--non-existant-script()
+  "Expects to not change variable value if the hook cannot find a
+directory script."
+  (let ((found nil)
+        (rootdirectory "/tmp/")
+        (subdirectory "/tmp/subdirectory/")
+        (file "testing-on-save.el"))
+    (unwind-protect
+        (progn
+          (dired-create-directory subdirectory)
+          ;; (copy-file on-folder-elisp-file (concat rootdirectory on-folder-elisp-file))
+          (add-hook 'after-save 'on-folder-elisp-hook)
+          (with-current-buffer
+              (find-file-noselect (concat subdirectory file))
+            (run-hooks 'after-save)))
+      (remove-hook 'after-save 'on-folder-elisp-hook)
+      (delete-file (concat subdirectory file))
+      (delete-directory subdirectory))
+    (should (eq found nil))))
+
+
+(ert-deftest test-on-folder-elisp-hook--nil-script-filename()
+  "Expects to not change variable value if the script filename is
+nil."
+  (let ((found nil)
+        (subdirectory "/tmp/subdirectory/")
+        (file "testing-on-save.el")
+        (on-folder-elisp-file nil))
+    (unwind-protect
+        (progn
+          (dired-create-directory subdirectory)
+          (add-hook 'after-save 'on-folder-elisp-hook)
+          (with-current-buffer
+              (find-file-noselect (concat subdirectory file))
+            (run-hooks 'after-save)))
+      (remove-hook 'after-save 'on-folder-elisp-hook)
+      (delete-file (concat subdirectory file))
+      (delete-directory subdirectory))
+    (should (eq found nil))))
+
+
+(ert-deftest test-on-folder-elisp-hook--empty-script-filename()
+  "Expects to not change variable value if the script filename is
+empty."
+  (let ((found nil)
+        (subdirectory "/tmp/subdirectory/")
+        (file "testing-on-save.el")
+        (on-folder-elisp-file ""))
+    (unwind-protect
+        (progn
+          (dired-create-directory subdirectory)
+          (add-hook 'after-save 'on-folder-elisp-hook)
+          (with-current-buffer
+              (find-file-noselect (concat subdirectory file))
+            (run-hooks 'after-save)))
+      (remove-hook 'after-save 'on-folder-elisp-hook)
+      (delete-file (concat subdirectory file))
+      (delete-directory subdirectory))
+    (should (eq found nil))))

--- a/INDEX
+++ b/INDEX
@@ -8,6 +8,8 @@ If you're in linux, write tree, copy and paste here
 │   ├── emacs-topics.org
 │   └── Lisp_notas_en_esp.pdf
 ├── Examples
+│   ├── on-folder-elisp.el
+│   ├── on-folder-elisp.test.el
 │   └── recommended-minimal-configuration.el
 ├── Exercices
 │   ├── Factorial
@@ -26,4 +28,4 @@ If you're in linux, write tree, copy and paste here
 │   └── scratch-testing-14042022.el
 └── update_index.sh
 
-7 directories, 16 files
+7 directories, 18 files


### PR DESCRIPTION
Look for a Elisp file named after `on-folder-elisp-file' variable  
on current or parent folder and eval the file if it is found.  The 
inspiration comes from                                             
http://www.howardism.org/Technical/Emacs/save-hooks.html by Howard 
where executes a script on a current directory or a parenting one. 
So I have just adapted a bit to evaluate a Elisp file.             

Includes also a Elisp on folder to update INDEX.